### PR TITLE
Add workflow to build and release Flutter APK

### DIFF
--- a/.github/workflows/flutter_release.yml
+++ b/.github/workflows/flutter_release.yml
@@ -1,0 +1,48 @@
+name: Build and Release Android APK
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build release APK
+        run: flutter build apk --release
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version:[ ]*//')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "v${{ steps.get_version.outputs.version }}"
+          name: "v${{ steps.get_version.outputs.version }}"
+          commit: ${{ github.sha }}
+          artifacts: build/app/outputs/flutter-apk/app-release.apk
+          artifactContentType: application/vnd.android.package-archive
+          generateReleaseNotes: true


### PR DESCRIPTION
## Summary
- add GitHub Action to build Android release APK when `main` is updated
- create a GitHub release using app version from `pubspec.yaml`